### PR TITLE
Add POC with typescript integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 react-app/node_modules
 react-app/dist
 svelte-app/node_modules
+svelte-app/types/react-app.d.ts
 svelte-app/src/v3/
 *.pyc
 .grunt

--- a/react-app/federation.config.json
+++ b/react-app/federation.config.json
@@ -1,0 +1,17 @@
+{
+  "name": "sharedComponents",
+  "filename": "remoteEntry.js",
+  "exposes": {
+    "./components/database-list": "./src/components/database-list/database-list.tsx",
+    "./components/project-list": "./src/components/project-list/project-list.tsx",
+    "./components/new-project": "./src/components/new-project/new-project.tsx"
+  },
+  "shared": {
+    "react": {
+      "requiredVersion": "^18.0.2"
+    },
+    "react-dom": {
+      "requiredVersion": "^18.0.2"
+    }
+  }
+}

--- a/react-app/make-federated-types.js
+++ b/react-app/make-federated-types.js
@@ -1,0 +1,124 @@
+import path from "path";
+import fs from "fs";
+import os from "os";
+import ts from "typescript";
+import federationConfig from "./federation.config.json" assert { type: "json" };
+
+const getArg = (argName) => {
+  const argIndex = process.argv.indexOf(argName);
+  return argIndex !== -1 ? process.argv[argIndex + 1] : null;
+};
+
+const outDirArg = getArg("--outputDir");
+const outputDir = outDirArg
+  ? path.resolve("./", outDirArg)
+  : path.resolve(__dirname, "../../@types/__federated_types/");
+
+const configPathArg = getArg("--config");
+const configPath = configPathArg ? path.resolve(configPathArg) : null;
+
+if (configPath && !fs.existsSync(configPath)) {
+  console.error(`ERROR: Unable to find a provided config: ${configPath}`);
+  process.exit(1);
+}
+
+const compileFiles = Object.values(federationConfig.exposes);
+const compileKeys = Object.keys(federationConfig.exposes);
+const outFile = path.resolve(outputDir, `${federationConfig.name}.d.ts`);
+
+try {
+  if (fs.existsSync(outFile)) {
+    fs.unlinkSync(outFile);
+  }
+
+  // write the typings file
+  const program = ts.createProgram(compileFiles, {
+    outFile,
+    declaration: true,
+    emitDeclarationOnly: true,
+    skipLibCheck: true,
+    jsx: "react",
+    esModuleInterop: true,
+  });
+
+  program.emit();
+
+  let typing = fs.readFileSync(outFile, { encoding: "utf8", flag: "r" });
+
+  const moduleRegex = RegExp(/declare module "(.*)"/, "g");
+  const moduleNames = [];
+
+  let execResults;
+
+  while ((execResults = moduleRegex.exec(typing)) !== null) {
+    moduleNames.push(execResults[1]);
+  }
+
+  // console.log("-----------");
+
+  moduleNames.forEach((name) => {
+    // exposeName - relative name of exposed component (if not found - just take moduleName)
+
+    const exposeName =
+      compileKeys.find((key) => {
+        const exposedPath = federationConfig.exposes[key];
+
+        // console.log({ exposedPath, name });
+        return exposedPath.includes(name);
+      }) || name;
+
+    // console.log({ exposeName });
+
+    const regex = RegExp(`"${name}"`, "g");
+    const moduleDeclareName = path
+      .join(federationConfig.name, exposeName)
+      .replace(/[\\/]/g, "/");
+    typing = typing.replace(regex, `"${moduleDeclareName}"`);
+  });
+
+  // console.log("-----------");
+  console.log("writing typing file:", outFile);
+
+  fs.writeFileSync(outFile, typing);
+
+  // if we are writing to the node_modules/@types directory, add a package.json file
+  if (
+    outputDir.includes(
+      os.platform() === "win32" ? "node_modules\\@types" : "node_modules/@types"
+    )
+  ) {
+    const packageJsonPath = path.resolve(outputDir, "package.json");
+
+    if (!fs.existsSync(packageJsonPath)) {
+      console.log("writing package.json:", packageJsonPath);
+      fs.copyFileSync(
+        path.resolve(__dirname, "typings.package.tmpl.json"),
+        packageJsonPath
+      );
+    } else {
+      console.log(packageJsonPath, "already exists");
+    }
+  } else {
+    console.log("not writing to node modules, dont need a package.json");
+  }
+
+  // write/update the index.d.ts file
+  const indexPath = path.resolve(outputDir, "index.d.ts");
+  const importStatement = `export * from './${federationConfig.name}';`;
+
+  if (!fs.existsSync(indexPath)) {
+    console.log("creating index.d.ts file");
+    fs.writeFileSync(indexPath, `${importStatement}\n`);
+  } else {
+    console.log("updating index.d.ts file");
+    const contents = fs.readFileSync(indexPath);
+    if (!contents.includes(importStatement)) {
+      fs.writeFileSync(indexPath, `${contents}${importStatement}\n`);
+    }
+  }
+
+  console.log("Success!");
+} catch (e) {
+  console.error(`ERROR:`, e);
+  process.exit(1);
+}

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && rm -rf ../svelte-app/src/v3/* && cp -R dist/assets/* ../svelte-app/src/v3/",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "make-types": "node ./make-federated-types.js --outputDir ./dist/types"
   },
   "dependencies": {
     "antd": "^5.4.0",

--- a/react-app/src/components/database-list/database-list.tsx
+++ b/react-app/src/components/database-list/database-list.tsx
@@ -4,46 +4,40 @@ import { Database } from "../../models/database";
 //refactor to service to emulate calling API
 
 const columns = [
-    {
-        title: 'Name',
-        dataIndex: 'name',
-        key: 'name'
-    },
-    {
-        title: 'Project',
-        dataIndex: 'project',
-        key: 'project'
-    },
-    {
-        title: 'Type',
-        dataIndex: 'type',
-        key: 'type'
-    },
-    {
-        title: 'Created By',
-        dataIndex: 'createdBy',
-        key: 'createdBy'
-    },
-    {
-        title: 'Status',
-        dataIndex: 'status',
-        key: 'status'
-    }
-]
-function DatabaseList(props: any){
+  {
+    title: "Name",
+    dataIndex: "name",
+    key: "name",
+  },
+  {
+    title: "Project",
+    dataIndex: "project",
+    key: "project",
+  },
+  {
+    title: "Type",
+    dataIndex: "type",
+    key: "type",
+  },
+  {
+    title: "Created By",
+    dataIndex: "createdBy",
+    key: "createdBy",
+  },
+  {
+    title: "Status",
+    dataIndex: "status",
+    key: "status",
+  },
+];
+function DatabaseList(props: { databases: Database[] }) {
+  let databases = props.databases;
 
-    let databases = props.databases as Database[];
-
-    if (databases && databases.length > 0) {
-        return (
-          <Table dataSource={databases} columns={columns} />
-        );
-    }
-    else {
-        return (
-          <div>No databases found</div>
-        );
-    }
+  if (databases && databases.length > 0) {
+    return <Table dataSource={databases} columns={columns} />;
+  } else {
+    return <div>No databases found</div>;
+  }
 }
 
 export default DatabaseList;

--- a/react-app/vite.config.ts
+++ b/react-app/vite.config.ts
@@ -1,33 +1,16 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import federation from "@originjs/vite-plugin-federation";
+// @ts-ignore
+import federationConfig from "./federation.config.json";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-      react(),
-      federation({
-      name: 'sharedComponents',
-      filename: 'remoteEntry.js',
-      exposes: {
-        './ProjectList': "./src/components/project-list/project-list.tsx",
-        './DatabaseList': "./src/components/database-list/database-list.tsx",
-        './NewProject': "./src/components/new-project/new-project.tsx",
-      },
-      shared: {
-        react: {
-          requiredVersion: "^18.0.2",
-        },
-        "react-dom": {
-          requiredVersion: "^18.0.2",
-        },
-      },
-    }),
-  ],
-    build: {
-        modulePreload: false,
-        target: 'esnext',
-        minify: false,
-        cssCodeSplit: false
-    }
-})
+  plugins: [react(), federation(federationConfig)],
+  build: {
+    modulePreload: false,
+    target: "esnext",
+    minify: false,
+    cssCodeSplit: false,
+  },
+});

--- a/svelte-app/fetch-types.js
+++ b/svelte-app/fetch-types.js
@@ -1,0 +1,13 @@
+import fs from 'fs/promises';
+import { join } from 'path';
+
+(async () => {
+	const REMOTE_URL = 'http://localhost:3000/';
+	const REMOTE_TYPES_URL = `${REMOTE_URL}types/sharedComponents.d.ts`;
+	const DESTINATION = join('./', 'types/react-app.d.ts');
+
+	const response = await fetch(REMOTE_TYPES_URL);
+	const types = await response.text();
+
+	await fs.writeFile(DESTINATION, types);
+})();

--- a/svelte-app/package-lock.json
+++ b/svelte-app/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@skeleton-elements/svelte": "^2.0.0",
-				"carbon-components-svelte": "^0.73.5"
+				"carbon-components-svelte": "^0.73.5",
+				"node-fetch": "^3.3.1"
 			},
 			"devDependencies": {
 				"@originjs/vite-plugin-federation": "^1.2.1",
@@ -1048,6 +1049,14 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1435,6 +1444,28 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1498,6 +1529,17 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/framework7-svelte": {
 			"version": "8.0.0",
@@ -1981,6 +2023,41 @@
 			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
 			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -2776,6 +2853,14 @@
 				"vite": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/which": {

--- a/svelte-app/package.json
+++ b/svelte-app/package.json
@@ -3,7 +3,8 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "npm run fetch-types && vite dev",
+		"fetch-types": "node fetch-types.js",
 		"build": "vite build",
 		"preview": "vite preview",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
@@ -20,6 +21,7 @@
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte3": "^4.0.0",
 		"framework7-svelte": "^8.0.0",
+		"node-fetch": "^3.3.1",
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.8.1",
 		"react": "^18.2.0",

--- a/svelte-app/src/component/DatabaseList.svelte
+++ b/svelte-app/src/component/DatabaseList.svelte
@@ -1,21 +1,24 @@
-<script>
-  import ReactWrapper from "./ReactWrapper.svelte";
-  import { onMount } from "svelte";
-  import { getDatabases } from "../services/database-service"
+<script lang="ts">
+	import ReactWrapper from './ReactWrapper.svelte';
+	import { onMount } from 'svelte';
+	import { getDatabases } from '../services/database-service';
+	import type DatabaseList from 'sharedComponents/components/database-list';
 
-  let DatabaseList;
-  let databases;
+	let DatabaseListComponent: typeof import('sharedComponents/components/database-list').default;
+	let props: Parameters<typeof DatabaseList>[0] = {
+		databases: []
+	};
+	onMount(async () => {
+		props.databases = getDatabases();
+		const { default: component } = await import('sharedComponents/components/database-list');
+		DatabaseListComponent = component;
+	});
 
-  onMount(async () => {
-    databases = getDatabases();
-    const { default: component } = await import('sharedComponents/DatabaseList');
-    DatabaseList = component;
-  });
+	// strictly defined props
 </script>
 
-{#if DatabaseList && databases && databases.length > 0 }
-{ console.debug(databases.length) }
-  <ReactWrapper component={DatabaseList} props = { {databases}}  />
+{#if DatabaseListComponent && props.databases && props.databases.length > 0}
+	<ReactWrapper component={DatabaseListComponent} {props} />
 {:else}
-  <p>Loading...</p>
+	<p>Loading...</p>
 {/if}

--- a/svelte-app/src/component/NewProject.svelte
+++ b/svelte-app/src/component/NewProject.svelte
@@ -1,18 +1,17 @@
 <script>
-	import ReactWrapper from "./ReactWrapper.svelte";
-	import { INewProject }  from "../models/new-project";
-	import { onMount } from "svelte";
-	
+	import ReactWrapper from './ReactWrapper.svelte';
+	import { onMount } from 'svelte';
+
 	let NewProject;
-  
+
 	onMount(async () => {
-	  const { default: component } = await import('sharedComponents/NewProject');
-	  NewProject = component;
+		const { default: component } = await import('sharedComponents/components/new-project');
+		NewProject = component;
 	});
-  </script>
-  
-  {#if NewProject }
+</script>
+
+{#if NewProject}
 	<ReactWrapper component={NewProject} />
-  {:else}
+{:else}
 	<p>Loading...</p>
-  {/if}
+{/if}

--- a/svelte-app/src/component/ProjectList.svelte
+++ b/svelte-app/src/component/ProjectList.svelte
@@ -1,17 +1,17 @@
 <script>
-  import ReactWrapper from "./ReactWrapper.svelte";
-  import { onMount } from "svelte";
+	import ReactWrapper from './ReactWrapper.svelte';
+	import { onMount } from 'svelte';
 
-let ProjectList;
+	let ProjectList;
 
-onMount(async () => {
-  const { default: component } = await import("sharedComponents/ProjectList");
-  ProjectList = component;
-});
+	onMount(async () => {
+		const { default: component } = await import('sharedComponents/components/project-list');
+		ProjectList = component;
+	});
 </script>
 
 {#if ProjectList}
-  <ReactWrapper component={ProjectList} />
+	<ReactWrapper component={ProjectList} />
 {:else}
-  <p>Loading...</p>
+	<p>Loading...</p>
 {/if}

--- a/svelte-app/src/models/database.ts
+++ b/svelte-app/src/models/database.ts
@@ -1,9 +1,0 @@
-// src/Project.ts
-export interface Database {
-    name: string;
-    project: string;
-    type: string;
-    status: string;
-    createdBy: string;
-    version: string;
-}

--- a/svelte-app/src/services/database-service.ts
+++ b/svelte-app/src/services/database-service.ts
@@ -1,17 +1,16 @@
-import type {Database} from '../models/database';
-import {getDatabaseNames} from "./database-names-service";
-import {getProjectNames } from "../../../react-app/src/services/project-names-service";
+import { getDatabaseNames } from './database-names-service';
+import { getProjectNames } from '../../../react-app/src/services/project-names-service';
 
-export function getDatabases(): Database[] {
-    const names = getDatabaseNames();
-    const projectNames = getProjectNames()
-    return Array.from({ length: 5 }, (_, index) => ({
-        key: index,
-        name: names[index],
-        project: projectNames[index],
-        type: "",
-        status: index % 2 === 0 ? "Active" : "Inactive",
-        createdBy: "Denis Rosa",
-        version: "7.1.2"
-    }));
+export function getDatabases() {
+	const names = getDatabaseNames();
+	const projectNames = getProjectNames();
+	return Array.from({ length: 5 }, (_, index) => ({
+		key: index,
+		name: names[index],
+		project: projectNames[index],
+		type: '',
+		status: index % 2 === 0 ? 'Active' : 'Inactive',
+		createdBy: 'Denis Rosa',
+		version: '7.1.2'
+	}));
 }

--- a/svelte-app/tsconfig.json
+++ b/svelte-app/tsconfig.json
@@ -11,15 +11,21 @@
 		"module": "ESNext",
 		"resolveJsonModule": true,
 		/**
-         * Typecheck JS in `.svelte` and `.js` files by default.
-         * Disable checkJs if you'd like to use dynamic types in JS.
-         * Note that setting allowJs false does not prevent the use
-         * of JS in `.svelte` files.
-         */
+		 * Typecheck JS in `.svelte` and `.js` files by default.
+		 * Disable checkJs if you'd like to use dynamic types in JS.
+		 * Note that setting allowJs false does not prevent the use
+		 * of JS in `.svelte` files.
+		 */
 		"allowJs": true,
 		"checkJs": true,
 		"isolatedModules": true
 	},
-	"include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+	"include": [
+		"src/**/*.d.ts",
+		"src/**/*.ts",
+		"src/**/*.js",
+		"src/**/*.svelte",
+		"types/react-app.d.ts"
+	],
 	"references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/svelte-app/vite.config.ts
+++ b/svelte-app/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import federation from '@originjs/vite-plugin-federation';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
+const REMOTE_URL = 'http://localhost:3000/';
 const allowedFiles = ['.'];
 
 export default defineConfig({
@@ -9,25 +10,26 @@ export default defineConfig({
 		//the size of .svelte-kit/output/client/_app/chunks/editor.api-b5cd19cc.js
 		//is 2574.37 KiB. Most likely, there is a way to reduce chunk size via manualChunks
 		//or dynamic import
-		chunkSizeWarningLimit: 1024 * 3,
+		chunkSizeWarningLimit: 1024 * 3
 	},
 	server: {
 		fs: {
-			allow: allowedFiles,
+			allow: allowedFiles
 		},
-		host: 'localhost',
+		host: 'localhost'
 	},
 	plugins: [
 		svelte(),
 		federation({
-			name: "svelte-app",
+			name: 'svelte-app',
 			remotes: {
-				sharedComponents: "./src/v3/remoteEntry.js",
+				// sharedComponents: "./src/v3/remoteEntry.js",
+				sharedComponents: `${REMOTE_URL}/assets/remoteEntry.js`
 			},
-			shared:['react', 'react-dom']
+			shared: ['react', 'react-dom']
 		})
 	],
 	optimizeDeps: {
-		exclude: ["@originjs/vite-plugin-federation"],
-	},
+		exclude: ['@originjs/vite-plugin-federation']
+	}
 });


### PR DESCRIPTION
## Problem
The current implementation of react-app components has resulted in the content and behavior being shared but not the types. As a consequence, when using these components in the svelte app, it becomes challenging to determine whether any interface has been modified.

## Solution
Proposed solution to this issue is to leverage typescript's capability to generate type definitions exclusively for exposed modules. By generating a type file and sharing it with the svelte app, we can ensure that our components are more resilient, and we can manage them in a safer manner.

## Instruction
1. Build the react-app by running `npm run build` in the react directory
2. Generate a file with type definitions by running `npm run make-types` in the react directory
3. Expose the build by running `npx serve dist --cors` from the `/dist` folder to host files on `http://localhost:3000`
4. Fetch the exposed types in the svelte directory by running `npm run fetch-types`
5. Run the svelte app using `npm run dev`
6. Enjoy the enhanced resilience and safety of our components!

## How it works
This solution is inspired by the [library](https://www.npmjs.com/package/@pixability-ui/federated-types), which scans the configuration of module federation and leverages typescript to extract definitions from the modules. Generated files are then saved in the `react-app/dist/types` directory and exposed on `http://localhost:3000/types/sharedComponents.d.ts`. To improve the configuration of the svelte app, we fetch these types just before the dev server starts and include them in the `tsconfig.json` file.

By including the shared types in the svelte app's configuration, we ensure that the components are using consistent type definitions, which will lead to fewer errors and more robust code. This approach allows us to build more reliable and maintainable applications.


## Examples

_DatabaseList.svelte_ – example with wrong types
```svelte
<script lang="ts">
	// ...

	let DatabaseListComponent: typeof import('sharedComponents/components/database-list').default;
	let props: Parameters<typeof DatabaseList>[0] = {
		databases: []
	};
	onMount(async () => {
		props.databases = [{ test: 'anything' }]; // wrong type, typescript throws error ❌
		const { default: component } = await import('sharedComponents/components/database-list');
		DatabaseListComponent = component;
	});

	// ...
</script>
```

_DatabaseList.svelte_ – example with fixed types
```svelte
<script lang="ts">
	// ...

	let DatabaseListComponent: typeof import('sharedComponents/components/database-list').default;
	let props: Parameters<typeof DatabaseList>[0] = {
		databases: []
	};
	onMount(async () => {
		props.databases = getDatabases(); // proper type, no errors! 🎉
		const { default: component } = await import('sharedComponents/components/database-list');
		DatabaseListComponent = component;
	});

	// ...
</script>
```

## Things to be improved
- maybe there's better way to extract types from exposed modules, I haven't found anything more interesting yet,
- I'm pretty sure we can leverage generic types and build `svelte-app/component/ReactWrapper.svelte` better way to infer properties from component, but have no idea how to do this in svelte
- I did an investigation how does it work in different libraries [dedicated for webpack](https://github.com/module-federation/typescript) – they use interval to update types, maybe it's not a bad idea to get inspired with that